### PR TITLE
genre filtering

### DIFF
--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/dto/AnimeDto.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/dto/AnimeDto.java
@@ -2,39 +2,16 @@ package cz.kocabek.animerecomedationsystem.recommendation.dto;
 
 import cz.kocabek.animerecomedationsystem.recommendation.entity.Anime;
 import jakarta.validation.constraints.NotNull;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * DTO for {@link Anime}
  */
 
-@Getter
-@EqualsAndHashCode
-@ToString
-public final class AnimeDto implements Serializable {
+
+public record AnimeDto(Long id, @NotNull String name, Double score, String imageURL) implements Serializable {
     @Serial
     private static final long serialVersionUID = 0L;
-    private final Long id;
-    private final @NotNull String name;
-    private final Double score;
-    private final String imageURL;
-    private final List<String> genres;
-
-    /**
-     *
-     */
-    public AnimeDto(Long id, @NotNull String name, Double score, String imageURL) {
-        this.id = id;
-        this.name = name;
-        this.score = score;
-        this.imageURL = imageURL;
-        this.genres = new ArrayList<>();
-    }
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/dto/AnimeOutDTO.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/dto/AnimeOutDTO.java
@@ -57,6 +57,7 @@ public class AnimeOutDTO {
         this.sumOfRatings = sumOfRatings;
         this.occurrences = occurrences;
         this.averageRating = null;
+        this.genres = new ArrayList<>();
     }
 
     /**

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/dto/AnimeOutDTO.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/dto/AnimeOutDTO.java
@@ -2,29 +2,83 @@ package cz.kocabek.animerecomedationsystem.recommendation.dto;
 
 import lombok.Data;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Data Transfer Object (DTO) representing output data related to concrete anime in the recommendation.
+ * <p>
+ * This class stores aggregated data about anime, including its unique ID, average rating,
+ * number of occurrences, percentage of total occurrences, and detailed information.
+ */
 @Data
 public class AnimeOutDTO {
+
+    /**
+     * The unique identifier of the anime.
+     */
     private Long animeId;
+
+    /**
+     * The average rating of the anime, calculated from user ratings.
+     */
     private Double averageRating;
+
+    /**
+     * The number of times the anime has been encountered or recommended.
+     */
     private int occurrences;
+
+    /**
+     * The percentage share of occurrences compared to other anime.
+     */
     private double percentageOccurrences;
+
+    /**
+     * Detailed information about the anime.
+     */
     private AnimeDto animeInfo;
+
+    /**
+     * The total sum of ratings received for this anime.
+     */
     private double sumOfRatings;
 
+    private List<String> genres;
+
+    /**
+     * Constructs a new {@code AnimeOutDTO} with the specified sum of ratings and number of occurrences.
+     * The average rating is initialized to {@code null}.
+     *
+     * @param sumOfRatings the total sum of ratings for the anime
+     * @param occurrences the number of times the anime has been recommended
+     */
     public AnimeOutDTO(double sumOfRatings, int occurrences) {
         this.sumOfRatings = sumOfRatings;
         this.occurrences = occurrences;
         this.averageRating = null;
     }
 
+    /**
+     * Increments the number of occurrences by one.
+     */
     public void incrementOccurrences() {
         this.occurrences++;
     }
 
+    /**
+     * Adds a given rating to the total sum of ratings.
+     *
+     * @param rating the rating to add
+     */
     public void addToRatingSum(double rating) {
         this.sumOfRatings += rating;
     }
 
+    /**
+     * Calculates the average rating by dividing the total sum of ratings
+     * by the number of occurrences, and updates the {@code averageRating} field.
+     */
     public void calculateAverageRating() {
         this.averageRating = this.sumOfRatings / this.occurrences;
     }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/repository/AnimeGenreRepository.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/repository/AnimeGenreRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 
 public interface AnimeGenreRepository extends Repository<AnimeGenre, AnimeGenreId> {
     List<AnimeGenreInfo> getById_AnimeIdIn(@NonNull Collection<Long> animeId);
+
+    List<AnimeGenreInfo> getAnimeGenresByAnimeId(Long animeId);
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/repository/AnimeRepository.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/repository/AnimeRepository.java
@@ -23,7 +23,9 @@ public interface AnimeRepository extends JpaRepository<Anime, Long> {
                         from Anime a
                         where a.id  in :animeIds
                         order by a.score DESC""")
-    List<AnimeDto> getAnimeListOrderByScore(@Param("animeIds") @NonNull Collection<Long> animeIds);
+    List<AnimeDto> getAnimeInfoListOrderByScore(@Param("animeIds") @NonNull Collection<Long> animeIds);
+
+
 
     @Query("select a.id from Anime a where lower(a.englishName) =?1")
     Optional<Long> getAnimeIdByEnglishName(String englishName);

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePredicate.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePredicate.java
@@ -1,0 +1,11 @@
+package cz.kocabek.animerecomedationsystem.recommendation.service;
+
+import cz.kocabek.animerecomedationsystem.recommendation.dto.AnimeOutDTO;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+@FunctionalInterface
+public interface AnimePredicate extends Predicate<Map.Entry<Long, AnimeOutDTO>> {
+    boolean test(Map.Entry<Long, AnimeOutDTO> animeMap);
+}

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePreprocessingService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePreprocessingService.java
@@ -5,32 +5,38 @@ import cz.kocabek.animerecomedationsystem.recommendation.service.RecommendationC
 import cz.kocabek.animerecomedationsystem.recommendation.service.db.AnimeGenreService;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class AnimePreprocessingService {
 
-    AnimeGenreService animeGenreService;
-    RecommendationConfig config;
+    final AnimeGenreService animeGenreService;
+    final RecommendationConfig config;
+    private final List<AnimePredicate> activeFilterList = new ArrayList<>();
 
-    AnimePreprocessingService(AnimeGenreService animeGenreService, RecommendationConfig config) {
+    public AnimePreprocessingService(AnimeGenreService animeGenreService, RecommendationConfig config) {
         this.animeGenreService = animeGenreService;
         this.config = config;
     }
 
-    public Map<Long, AnimeOutDTO> filterAnime(Map<Long, AnimeOutDTO> animeMap) {
-        final var map = new HashMap<>(animeMap);
-        if (config.isOnlyInAnimeGenres()) {
-            final var genres = animeGenreService.getGenresForAnime(config.getAnimeId());
-            filterOutByInputGenres(map, genres);
-        }
-        return map;
+    public Map<Long, AnimeOutDTO> filterAnimeMap(Map<Long, AnimeOutDTO> animeMap) {
+        selectFilters();
+        return animeMap.entrySet().stream().filter(combineFilters())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (_, b) -> b));
     }
 
-    private void filterOutByInputGenres(Map<Long, AnimeOutDTO> map, List<String> genres) {
-        map.entrySet().removeIf(entry ->
-                entry.getValue().getGenres().stream().noneMatch(genres::contains));
+    private void selectFilters() {
+        activeFilterList.clear();
+        if (config.isOnlyInAnimeGenres()) {
+            final var genres = animeGenreService.getGenresForAnime(config.getAnimeId());
+            activeFilterList.add(entry -> entry.getValue().getGenres().stream().anyMatch(genres::contains));
+        }
+    }
+
+    private AnimePredicate combineFilters() {
+        return activeFilterList.stream().reduce(_ -> true, (f1, f2) -> entry -> f1.test(entry) && f2.test(entry), (f1, _) -> f1);
     }
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePreprocessingService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePreprocessingService.java
@@ -1,0 +1,33 @@
+package cz.kocabek.animerecomedationsystem.recommendation.service;
+
+import cz.kocabek.animerecomedationsystem.recommendation.dto.AnimeOutDTO;
+import cz.kocabek.animerecomedationsystem.recommendation.service.RecommendationConfig.RecommendationConfig;
+import cz.kocabek.animerecomedationsystem.recommendation.service.db.AnimeGenreService;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class AnimePreprocessingService {
+
+    AnimeGenreService animeGenreService;
+    RecommendationConfig config;
+
+    AnimePreprocessingService(AnimeGenreService animeGenreService, RecommendationConfig config) {
+        this.animeGenreService = animeGenreService;
+        this.config = config;
+    }
+
+    public Map<Long, AnimeOutDTO> filterAnime(Map<Long, AnimeOutDTO> animeMap) {
+        final var map = new HashMap<>(animeMap);
+        if (config.isOnlyInAnimeGenres()) filterOutByInputGenres(map, config.getAnimeId());
+        return map;
+    }
+
+    private void filterOutByInputGenres(Map<Long, AnimeOutDTO> map, Long animeId) {
+        final var genres = animeGenreService.getGenresForAnime(animeId);
+        map.entrySet().removeIf(entry ->
+                entry.getValue().getGenres().stream().noneMatch(genres::contains));
+    }
+}

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePreprocessingService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/AnimePreprocessingService.java
@@ -6,6 +6,7 @@ import cz.kocabek.animerecomedationsystem.recommendation.service.db.AnimeGenreSe
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -21,12 +22,14 @@ public class AnimePreprocessingService {
 
     public Map<Long, AnimeOutDTO> filterAnime(Map<Long, AnimeOutDTO> animeMap) {
         final var map = new HashMap<>(animeMap);
-        if (config.isOnlyInAnimeGenres()) filterOutByInputGenres(map, config.getAnimeId());
+        if (config.isOnlyInAnimeGenres()) {
+            final var genres = animeGenreService.getGenresForAnime(config.getAnimeId());
+            filterOutByInputGenres(map, genres);
+        }
         return map;
     }
 
-    private void filterOutByInputGenres(Map<Long, AnimeOutDTO> map, Long animeId) {
-        final var genres = animeGenreService.getGenresForAnime(animeId);
+    private void filterOutByInputGenres(Map<Long, AnimeOutDTO> map, List<String> genres) {
         map.entrySet().removeIf(entry ->
                 entry.getValue().getGenres().stream().noneMatch(genres::contains));
     }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
@@ -27,13 +27,14 @@ public class RecommendationEngine {
     }
 
 
-    /** counting detail occurrences in the given users detail lists
-     * automatically transfers dta from list to map
+    /**
+     *transform List of UsersAnimeLists to a Map of anime's
+     * and count basic data about each anime for future calculation in the recommendation engine
      *
-     * @param userAnimeLists @List<{@link UserAnimeList>} users detail lists with detail IDs and their respective ratings
+     * @param userAnimeLists @List<{@link UserAnimeList} users anime lists with anime IDs and their respective ratings>
      *
      *
-     *  @return @Map<{@link Long}, {@link Integer}> detail ID and its occurrence across the Users
+     *  @return @Map<{@link Long} ID of anime, {@link AnimeOutDTO} DTO with all information about that anime>
      *
      */
     private Map<Long, AnimeOutDTO> countAnimeOccurrences(List<UserAnimeList> userAnimeLists) {
@@ -83,16 +84,16 @@ public class RecommendationEngine {
     }
 
     /**
-     * Processes a list of user detail ratings to build a sorted map of detail occurrences with calculated statistics.
+     * Processes a List of users list of rated anime to build a map of anime occurrences with calculated statistics.
      * This method performs the following operations:
-     * 1. Counts how many times each detail appears across all user lists
-     * 2. Calculates the average rating for each detail
-     * 3. Calculates the percentage of occurrence for each detail
-     * 4. Sorts the detail by their occurrence count in descending order
+     * 1. Counts how many times each anime appears across all user lists
+     * 2. Calculates the average rating for each anime
+     * 3. Calculates the percentage of occurrence for each anime
+     * 4. Sorts the anime by their occurrence count in descending order
      *
      * @param animeLists a list of UserAnimeList objects containing user IDs and their detail ratings
-     * @return a sorted Map where keys are detail IDs and values are AnimeOutDTO objects containing
-     *         occurrence statistics and rating information
+     * @return a sorted Map where keys are anime IDs and values are AnimeOutDTO objects containing
+     *         occurrence statistics and rating information about the anime
      */
     Map<Long, AnimeOutDTO> buildAnimeOccurrencesMap(List<UserAnimeList> animeLists) {
         final var map = countAnimeOccurrences(animeLists);

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
@@ -104,7 +104,7 @@ public class RecommendationEngine {
     }
 
     Map<Long, AnimeOutDTO> filteredAndSortAnimeMap(List<UserAnimeList> animeLists, Map<Long, AnimeOutDTO> map) {
-        final var filteredMap = animePreprocessingService.filterAnime(map);
+        final var filteredMap = animePreprocessingService.filterAnimeMap(map);
         logger.debug("size of all anime: {}", filteredMap.size());
         calculateAverageRatings(filteredMap);
         calculatePercentageOccurrencesAmongUsers(filteredMap, animeLists.size());

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
@@ -39,7 +39,7 @@ public class RecommendationEngine {
      *  @return @Map<{@link Long} ID of anime, {@link AnimeOutDTO} DTO with all information about that anime>
      *
      */
-    private Map<Long, AnimeOutDTO> countAnimeOccurrences(List<UserAnimeList> userAnimeLists) {
+    private Map<Long, AnimeOutDTO> transformUsersListsToAnimeMap(List<UserAnimeList> userAnimeLists) {
         logger.debug("number of users: {}", userAnimeLists.size());
         final Map<Long, AnimeOutDTO> result = new LinkedHashMap<>();
         for (UserAnimeList user : userAnimeLists) {

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
@@ -22,8 +22,10 @@ import java.util.stream.Collectors;
 public class RecommendationEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(RecommendationEngine.class);
+    AnimePreprocessingService animePreprocessingService;
 
-    public RecommendationEngine() {
+    public RecommendationEngine(AnimePreprocessingService animePreprocessingService) {
+        this.animePreprocessingService = animePreprocessingService;
     }
 
 
@@ -95,11 +97,17 @@ public class RecommendationEngine {
      * @return a sorted Map where keys are anime IDs and values are AnimeOutDTO objects containing
      *         occurrence statistics and rating information about the anime
      */
-    Map<Long, AnimeOutDTO> buildAnimeOccurrencesMap(List<UserAnimeList> animeLists) {
-        final var map = countAnimeOccurrences(animeLists);
-        logger.debug("size of all detail: {}", map.size());
-        calculateAverageRatings(map);
-        calculatePercentageOccurrencesAmongUsers(map, animeLists.size());
-        return sortAnimeMapByOccurrences(map);
+    Map<Long, AnimeOutDTO> buildAnimeMap(List<UserAnimeList> animeLists) {
+        return transformUsersListsToAnimeMap(animeLists);
+
+        //return generateAnimeRecommendations(animeLists, map);
+    }
+
+    Map<Long, AnimeOutDTO> filteredAndSortAnimeMap(List<UserAnimeList> animeLists, Map<Long, AnimeOutDTO> map) {
+        final var filteredMap = animePreprocessingService.filterAnime(map);
+        logger.debug("size of all anime: {}", filteredMap.size());
+        calculateAverageRatings(filteredMap);
+        calculatePercentageOccurrencesAmongUsers(filteredMap, animeLists.size());
+        return sortAnimeMapByOccurrences(filteredMap);
     }
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationEngine.java
@@ -39,7 +39,7 @@ public class RecommendationEngine {
      *  @return @Map<{@link Long} ID of anime, {@link AnimeOutDTO} DTO with all information about that anime>
      *
      */
-    private Map<Long, AnimeOutDTO> transformUsersListsToAnimeMap(List<UserAnimeList> userAnimeLists) {
+     Map<Long, AnimeOutDTO> buildAnimeMap(List<UserAnimeList> userAnimeLists) {
         logger.debug("number of users: {}", userAnimeLists.size());
         final Map<Long, AnimeOutDTO> result = new LinkedHashMap<>();
         for (UserAnimeList user : userAnimeLists) {
@@ -97,11 +97,7 @@ public class RecommendationEngine {
      * @return a sorted Map where keys are anime IDs and values are AnimeOutDTO objects containing
      *         occurrence statistics and rating information about the anime
      */
-    Map<Long, AnimeOutDTO> buildAnimeMap(List<UserAnimeList> animeLists) {
-        return transformUsersListsToAnimeMap(animeLists);
 
-        //return generateAnimeRecommendations(animeLists, map);
-    }
 
     Map<Long, AnimeOutDTO> filteredAndSortAnimeMap(List<UserAnimeList> animeLists, Map<Long, AnimeOutDTO> map) {
         final var filteredMap = animePreprocessingService.filterAnimeMap(map);

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationService.java
@@ -29,9 +29,13 @@ import java.util.Map;
 public class RecommendationService {
     private static final Logger logger = LoggerFactory.getLogger(RecommendationService.class);
 
+    /* db services */
     AnimeService animeService;
     UserAnimeScoreService userAnimeScoreService;
+    AnimeGenreService animeGenreService;
+    //    algorithm service
     RecommendationEngine engine;
+    //service for building output DTO
     DTOResultBuilder resultBuilder;
     AnimeGenreService animeGenreService;
 
@@ -47,12 +51,12 @@ public class RecommendationService {
     /*---*/
 
     /**
-     * Generates detail recommendations for a given detail ID using an intersection weight algorithm
+     * Generates anime recommendations for a given anime ID using an intersection weight algorithm
      * along with various processing and analysis steps to refine the recommendations.
      *
-     * @param animeId the ID of the detail for which recommendations are generated
-     * @return a {@link RecommendationDTO} object containing the input detail names
-     *         and a list of recommended detail
+     * @param animeId the ID of the anime for which recommendations are generated
+     * @return a {@link RecommendationDTO} object containing the input anime names
+     *         and a list of recommended anime's
      */
     private RecommendationDTO generateAnimeRecommendations(Long animeId) {
         //collecting and grouping data from the database into a list of users Anime lists

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationService.java
@@ -37,7 +37,6 @@ public class RecommendationService {
     RecommendationEngine engine;
     //service for building output DTO
     DTOResultBuilder resultBuilder;
-    AnimeGenreService animeGenreService;
 
     /* public endpoints*/
     public RecommendationDTO getAnimeRecommendation(String name) {

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/RecommendationService.java
@@ -73,10 +73,10 @@ public class RecommendationService {
         final var mapWithDetails = enrichedMapByDetails(animeMap);
         final var processedMap = engine.filteredAndSortAnimeMap(usersAnimeLists, mapWithDetails);
         long step3Start = System.nanoTime();
-        final var weightedAnime = engine.weightAnime(sortedMap, AnimeScoreCalculator.compositeScoring);
-        final var topRecommendations = engine.cutTheTopN(weightedAnime);//current final map with ids without detail yet
+        final var weightedAnime = engine.weightAnime(processedMap, AnimeScoreCalculator.compositeScoring);
+        final var topRecommendations = engine.cutTheTopN(weightedAnime);//current final anime map with ids without detail yet
         long step3Duration = (System.nanoTime() - step3Start) / 1_000_000;
-        logger.warn("Step 3 (weight detail) took: {} ms", step3Duration);
+        logger.warn("Step 3 (weighted anime's) took: {} ms", step3Duration);
         logger.debug("size of shortened list: {}", topRecommendations.size());
         long step4Start = System.nanoTime();
         //get anime details separately
@@ -94,7 +94,7 @@ public class RecommendationService {
 
     private RecommendationDTO buildOutputList(List<AnimeDto> animeDetails, Map<Long, AnimeOutDTO> outDTO) {
         for (AnimeDto detail : animeDetails) {
-            outDTO.get(detail.getId()).setAnimeInfo(detail);
+            outDTO.get(detail.id()).setAnimeInfo(detail);
         }
         return resultBuilder.addRecommendation(convertToAnimeList(outDTO)).build();
     }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/db/AnimeGenreService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/db/AnimeGenreService.java
@@ -18,7 +18,7 @@ public class AnimeGenreService {
         this.repository = repository;
     }
 
-    public Map<Long, List<String>> getGenresForAnime(Collection<Long> animeIds) {
+    public Map<Long, List<String>> getGenresByAnimeIds(Collection<Long> animeIds) {
         final var animeGenreInfos = repository.getById_AnimeIdIn(animeIds);
         return groupGenrePerAnime(animeGenreInfos);
     }
@@ -33,6 +33,6 @@ public class AnimeGenreService {
                 Collectors.groupingBy(info -> info.getAnime().getId(),
                         Collectors.mapping(info -> info.getGenre().getGenreName(),
                                 Collectors.toList())
-               ));
+                ));
     }
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/db/AnimeGenreService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/db/AnimeGenreService.java
@@ -23,6 +23,11 @@ public class AnimeGenreService {
         return groupGenrePerAnime(animeGenreInfos);
     }
 
+    public List<String> getGenresForAnime(Long animeId) {
+        final var genres = repository.getAnimeGenresByAnimeId(animeId);
+        return genres.stream().map(info -> info.getGenre().getGenreName()).toList();
+    }
+
     private Map<Long, List<String>> groupGenrePerAnime(List<AnimeGenreInfo> genreInfos) {
         return genreInfos.stream().collect(
                 Collectors.groupingBy(info -> info.getAnime().getId(),

--- a/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/db/AnimeService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/recommendation/service/db/AnimeService.java
@@ -36,8 +36,8 @@ public class AnimeService {
                         .orElseThrow(() -> new ValidationException("This anime was not found.%nTry again with different name".formatted())));
     }
 
-    public List<AnimeDto> getListAnimeFromIds(Collection<Long> ids) {
-        return animeRepository.getAnimeListOrderByScore(ids);
+    public List<AnimeDto> retrieveAnimeByIdsSortedByScore(Collection<Long> ids) {
+        return animeRepository.getAnimeInfoListOrderByScore(ids);
     }
 
     public Collection<String> getAnimeNamesByIds(Collection<Long> animeIds) {

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/config/AuthConfig.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/config/AuthConfig.java
@@ -16,7 +16,7 @@ public class AuthConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http.authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/", "/main", "/submit","/result","result/submit","/register","/assets/**").permitAll()
+                        .requestMatchers("/", "/main", "/submit","/result","result/submit","/register","/assets/**","/error").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -63,7 +63,7 @@
                                     <!-- Right side: Genre pills aligned to right -->
                                     <div class="d-flex flex-column align-items-end ms-auto">
                                         <span class="badge bg-secondary mb-2">Genres:</span>
-                                        <span th:each="genre : ${recommend.animeInfo.genres}"
+                                        <span th:each="genre : ${recommend.genres}"
                                               class="badge rounded-pill bg-secondary mb-1"
                                               th:text="${genre}"></span>
                                     </div>


### PR DESCRIPTION
adding ability to filter only anime which has at least one of the genre common with the input anime.

## Summary by Sourcery

Add genre-based filtering to the anime recommendation pipeline and refactor recommendation components for clearer data flow.

New Features:
- Introduce AnimePreprocessingService and AnimePredicate for configurable genre-based filtering.
- Enable filtering of recommended anime to only those sharing genres with the input anime (controlled via configuration).

Enhancements:
- Refactor RecommendationService and RecommendationEngine to separate map building, enrichment, filtering, and weighting steps.
- Extend AnimeOutDTO to include genre lists and enrich recommendation results with genre data.
- Convert AnimeDto to a Java record and rename repository/service methods for clarity and consistency.

Chores:
- Update security configuration to permit the "/error" endpoint.
- Adjust Thymeleaf result template to correctly render genres from the recommendation model.