### PR TITLE
Activate the 'dev' profile by default

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,32 @@
+spring:
+  profiles: dev
+  application:
+    name: animeRecommendationSystem
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3307/mydatabase
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        "format_sql": true
+        "generate_statistics": true
+debug: true
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
+        type:
+          descriptor:
+            sql:
+              spi: trace
+        stat: DEBUG
+    root: INFO
+    cz:
+      kocabek:
+        animerecomedationsystem: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,35 +1,4 @@
-# Conversion to YAML from Properties formar report
-# Warnings:
-# - The yaml file had comments which are lost in the refactoring!
 spring:
-  application:
-    name: animeRecommendationSystem
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3307/mydatabase
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        '[format_sql]': true
-        '[generate_statistics]': true
-debug: true
-logging:
-  level:
-    org:
-      hibernate:
-        sql: debug
-        type:
-          descriptor:
-            sql:
-              spi: trace
-        stat: DEBUG
-    root: INFO
-    cz:
-      kocabek:
-        animerecomedationsystem:
-          service: debug
+  profiles:
+    active:
+    - dev


### PR DESCRIPTION
## Summary by Sourcery

Activate the dev profile by default and consolidate development configuration into a dedicated application-dev.yml file.

Enhancements:
- Enable the 'dev' Spring profile by default in application.yml
- Extract all development-specific datasource and logging settings into application-dev.yml