### PR TITLE
Add password change functionality and settings page

### DIFF
--- a/src/main/java/cz/kocabek/animerecomedationsystem/account/repository/AppAccRepository.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/account/repository/AppAccRepository.java
@@ -3,16 +3,32 @@ package cz.kocabek.animerecomedationsystem.account.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
+import org.springframework.transaction.annotation.Transactional;
 
 import cz.kocabek.animerecomedationsystem.account.entity.AppAccount;
 
 public interface AppAccRepository extends JpaRepository<AppAccount, Integer> {
+
     Optional<AppAccount> findByUsername(String username);
 
     @Query("select a.id from AppAccount a where a.username = ?1")
     @NonNull
     Optional<Integer> findAccountIdByUsername(@NonNull String username);
+
+    @Query("select a.passwordHash from AppAccount a where a.id =?1 ")
+    String findAccountPasswordById(@NonNull Integer id);
+
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE AppAccount a
+        SET a.passwordHash = :password
+        WHERE a.id = :id
+            """)
+    int updatePassword(@NonNull @Param("id") Integer id, @Param("password") String pass);
 
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/config/AuthConfig.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/config/AuthConfig.java
@@ -5,8 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -36,8 +34,5 @@ public class AuthConfig {
                 .logout(LogoutConfigurer::permitAll).build();
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+   
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/config/SecurityConfig.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package cz.kocabek.animerecomedationsystem.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -55,7 +55,7 @@ public class MainController {
         return "redirect:/";
     }
 
-    @GetMapping("/setting")
+    @GetMapping("/settings")
     public String getSettingPage(Model model) {
         model.addAttribute("passwordForm", new SettingDTO());
         return SETTING_ENDPOINT;

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -13,13 +13,24 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import cz.kocabek.animerecomedationsystem.security.dto.RegistrationDTO;
+import cz.kocabek.animerecomedationsystem.security.dto.SettingDTO;
+import cz.kocabek.animerecomedationsystem.security.service.PasswordService;
+import cz.kocabek.animerecomedationsystem.security.service.RegistrationService;
+import jakarta.validation.Valid;
+
 @Controller
 public class MainController {
+
+    private final PasswordService passwordService;
+
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(MainController.class);
+    private static final String REG_ENDPOINT = "auth/registration";
     RegistrationService registration;
 
-    public MainController(RegistrationService registration) {
+    public MainController(RegistrationService registration, PasswordService passwordService) {
         this.registration = registration;
+        this.passwordService = passwordService;
     }
 
     @GetMapping("/")
@@ -31,19 +42,36 @@ public class MainController {
     public String getRegisterPage(Model model) {
         RegistrationDTO account = new RegistrationDTO();
         model.addAttribute("account", account);
-        return "auth/registration";
+        return REG_ENDPOINT;
     }
 
     @PostMapping("/register")
     public String register(@Valid @ModelAttribute("account") RegistrationDTO acc, BindingResult result, RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
-            return "auth/registration";
+            return REG_ENDPOINT;
         }
         if (!registration.registerNewUser(acc)) {
             result.rejectValue("username", "error.detail", "Username already exists");
-            return "auth/registration";
+            return REG_ENDPOINT;
         }
         redirectAttributes.addFlashAttribute("successMessage", "Your account was created successfully. You can now sign in.");
         return "redirect:/";
     }
+
+    @GetMapping("/setting")
+    public String getSettingPage(Model model) {
+        model.addAttribute("passwordForm", new SettingDTO());
+        return "settings";
+    }
+
+    @PostMapping("/changePassword")
+    public String changePassword(@Valid @ModelAttribute("passwordForm") SettingDTO form, BindingResult result) {
+        if (result.hasErrors()) {
+            return "settings";
+        }
+        final var check = passwordService.checkPassword(form);
+        LOGGER.debug("the check was  {}", check);
+        return "redirect:/main";
+    }
+
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -72,7 +72,7 @@ public class MainController {
         }
         passwordService.changePassword(settingForm);
         redirectAttributes.addFlashAttribute("successMessage", "Your password was changed successfully.");
-        return "redirect:/main";
+        return "redirect:/";
     }
 
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -1,9 +1,5 @@
 package cz.kocabek.animerecomedationsystem.security.controller;
 
-
-import cz.kocabek.animerecomedationsystem.security.dto.RegistrationDTO;
-import cz.kocabek.animerecomedationsystem.security.service.RegistrationService;
-import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -62,7 +62,7 @@ public class MainController {
     }
 
     @PostMapping("/changePassword")
-    public String changePassword(@Valid @ModelAttribute("passwordForm") SettingDTO settingForm, BindingResult result) {
+    public String changePassword(@Valid @ModelAttribute("passwordForm") SettingDTO settingForm, BindingResult result, RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
             return SETTING_ENDPOINT;
         }
@@ -71,6 +71,7 @@ public class MainController {
             return SETTING_ENDPOINT;
         }
         passwordService.changePassword(settingForm);
+        redirectAttributes.addFlashAttribute("successMessage", "Your password was changed successfully.");
         return "redirect:/main";
     }
 

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -19,10 +19,11 @@ import jakarta.validation.Valid;
 public class MainController {
 
     private final PasswordService passwordService;
+    private final RegistrationService registration;
 
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(MainController.class);
     private static final String REG_ENDPOINT = "auth/registration";
-    RegistrationService registration;
+    private static final String SETTING_ENDPOINT = "settings";
 
     public MainController(RegistrationService registration, PasswordService passwordService) {
         this.registration = registration;
@@ -57,17 +58,17 @@ public class MainController {
     @GetMapping("/setting")
     public String getSettingPage(Model model) {
         model.addAttribute("passwordForm", new SettingDTO());
-        return "settings";
+        return SETTING_ENDPOINT;
     }
 
     @PostMapping("/changePassword")
     public String changePassword(@Valid @ModelAttribute("passwordForm") SettingDTO settingForm, BindingResult result) {
         if (result.hasErrors()) {
-            return "settings";
+            return SETTING_ENDPOINT;
         }
         if (!passwordService.checkPassword(settingForm)) {
             result.rejectValue("oldPass", "error.nonMatchingPassword", "your Current Password don't match. Try again");
-            return "settings";
+            return SETTING_ENDPOINT;
         }
         passwordService.changePassword(settingForm);
         return "redirect:/main";

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/controller/MainController.java
@@ -61,12 +61,15 @@ public class MainController {
     }
 
     @PostMapping("/changePassword")
-    public String changePassword(@Valid @ModelAttribute("passwordForm") SettingDTO form, BindingResult result) {
+    public String changePassword(@Valid @ModelAttribute("passwordForm") SettingDTO settingForm, BindingResult result) {
         if (result.hasErrors()) {
             return "settings";
         }
-        final var check = passwordService.checkPassword(form);
-        LOGGER.debug("the check was  {}", check);
+        if (!passwordService.checkPassword(settingForm)) {
+            result.rejectValue("oldPass", "error.nonMatchingPassword", "your Current Password don't match. Try again");
+            return "settings";
+        }
+        passwordService.changePassword(settingForm);
         return "redirect:/main";
     }
 

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/dto/SettingDTO.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/dto/SettingDTO.java
@@ -1,0 +1,14 @@
+package cz.kocabek.animerecomedationsystem.security.dto;
+
+import cz.kocabek.animerecomedationsystem.security.validation.Password;
+
+public record SettingDTO(
+        String oldPass,
+        @Password
+        String newPass
+        ) {
+
+    public SettingDTO() {
+        this(null, null);
+    }
+}

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/dto/SettingDTO.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/dto/SettingDTO.java
@@ -1,8 +1,10 @@
 package cz.kocabek.animerecomedationsystem.security.dto;
 
 import cz.kocabek.animerecomedationsystem.security.validation.Password;
+import jakarta.validation.constraints.NotBlank;
 
 public record SettingDTO(
+    @NotBlank
         String oldPass,
         @Password
         String newPass

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
@@ -1,0 +1,33 @@
+package cz.kocabek.animerecomedationsystem.security.service;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import cz.kocabek.animerecomedationsystem.account.UserSessionData;
+import cz.kocabek.animerecomedationsystem.account.repository.AppAccRepository;
+import cz.kocabek.animerecomedationsystem.security.dto.SettingDTO;
+import jakarta.persistence.EntityManager;
+
+@Service
+public class PasswordService {
+
+    private final AppAccRepository appAccRepository;
+    private final UserSessionData userSessionData;
+    private final BCryptPasswordEncoder encoder;
+
+    PasswordService(AppAccRepository appAccRepository, UserSessionData userSessionData, EntityManager entityManager) {
+        this.appAccRepository = appAccRepository;
+        this.userSessionData = userSessionData;
+        encoder = new BCryptPasswordEncoder();
+    }
+
+    public boolean checkPassword(SettingDTO setting) {
+        final var oldPass = appAccRepository.findAccountPasswordById(userSessionData.getUserId());
+        if (!encoder.matches(setting.oldPass(), oldPass)) {
+            return false;
+        }
+        final var newHash = encoder.encode(setting.newPass());
+        appAccRepository.updatePassword(userSessionData.getUserId(), newHash);
+        return true;
+    }
+}

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
@@ -2,11 +2,11 @@ package cz.kocabek.animerecomedationsystem.security.service;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import cz.kocabek.animerecomedationsystem.account.UserSessionData;
 import cz.kocabek.animerecomedationsystem.account.repository.AppAccRepository;
 import cz.kocabek.animerecomedationsystem.security.dto.SettingDTO;
-import jakarta.persistence.EntityManager;
 
 @Service
 public class PasswordService {
@@ -15,7 +15,7 @@ public class PasswordService {
     private final UserSessionData userSessionData;
     private final BCryptPasswordEncoder encoder;
 
-    PasswordService(AppAccRepository appAccRepository, UserSessionData userSessionData, EntityManager entityManager) {
+    PasswordService(AppAccRepository appAccRepository, UserSessionData userSessionData) {
         this.appAccRepository = appAccRepository;
         this.userSessionData = userSessionData;
         encoder = new BCryptPasswordEncoder();
@@ -23,11 +23,12 @@ public class PasswordService {
 
     public boolean checkPassword(SettingDTO setting) {
         final var oldPass = appAccRepository.findAccountPasswordById(userSessionData.getUserId());
-        if (!encoder.matches(setting.oldPass(), oldPass)) {
-            return false;
-        }
+        return encoder.matches(setting.oldPass(), oldPass);
+    }
+
+    @Transactional
+    public void changePassword(SettingDTO setting) {
         final var newHash = encoder.encode(setting.newPass());
         appAccRepository.updatePassword(userSessionData.getUserId(), newHash);
-        return true;
     }
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
@@ -28,7 +28,10 @@ public class PasswordService {
         final var newHash = passwordEncoder.encode(setting.newPass());
         final var rows = appAccRepository.updatePassword(userSessionData.getUserId(), newHash);
         if (rows != 1) {
-            throw new NoTransactionException("");
+            throw new NoTransactionException(
+                "Failed to update password for userId: " + userSessionData.getUserId() +
+                ". Expected 1 row to be updated, but got: " + rows
+            );
         }
     }
 }

--- a/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
+++ b/src/main/java/cz/kocabek/animerecomedationsystem/security/service/PasswordService.java
@@ -1,34 +1,34 @@
 package cz.kocabek.animerecomedationsystem.security.service;
 
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.NoTransactionException;
 import org.springframework.transaction.annotation.Transactional;
 
 import cz.kocabek.animerecomedationsystem.account.UserSessionData;
 import cz.kocabek.animerecomedationsystem.account.repository.AppAccRepository;
 import cz.kocabek.animerecomedationsystem.security.dto.SettingDTO;
+import lombok.AllArgsConstructor;
 
 @Service
+@AllArgsConstructor
 public class PasswordService {
 
     private final AppAccRepository appAccRepository;
     private final UserSessionData userSessionData;
-    private final BCryptPasswordEncoder encoder;
-
-    PasswordService(AppAccRepository appAccRepository, UserSessionData userSessionData) {
-        this.appAccRepository = appAccRepository;
-        this.userSessionData = userSessionData;
-        encoder = new BCryptPasswordEncoder();
-    }
+    private final PasswordEncoder passwordEncoder;
 
     public boolean checkPassword(SettingDTO setting) {
         final var oldPass = appAccRepository.findAccountPasswordById(userSessionData.getUserId());
-        return encoder.matches(setting.oldPass(), oldPass);
+        return passwordEncoder.matches(setting.oldPass(), oldPass);
     }
 
     @Transactional
     public void changePassword(SettingDTO setting) {
-        final var newHash = encoder.encode(setting.newPass());
-        appAccRepository.updatePassword(userSessionData.getUserId(), newHash);
+        final var newHash = passwordEncoder.encode(setting.newPass());
+        final var rows = appAccRepository.updatePassword(userSessionData.getUserId(), newHash);
+        if (rows != 1) {
+            throw new NoTransactionException("");
+        }
     }
 }

--- a/src/main/resources/static/assets/css/main.css
+++ b/src/main/resources/static/assets/css/main.css
@@ -88,10 +88,14 @@
 }
 
 .header-bg {
-        background-image: url('../image/ian-valerio-road-header-unsplash.jpg');
-        background-size: cover;
-        background-position: center;
-        filter: brightness(1);
-        /* Adjust brightness to make text pop */
-        z-index: 1;
-    }
+    background-image: url('../image/ian-valerio-road-header-unsplash.jpg');
+    background-size: cover;
+    background-position: center;
+    filter: brightness(1);
+    /* Adjust brightness to make text pop */
+    z-index: 1;
+}
+
+#main-page {
+    background-image: url('../image/ian-valerio-road-header-unsplash.jpg');
+}

--- a/src/main/resources/templates/auth/index.html
+++ b/src/main/resources/templates/auth/index.html
@@ -23,13 +23,12 @@
     <!-- Header Transparent -->
     <header th:replace="~{auth/fragment/header :: header}"></header>
     <!-- End Header -->
-    <div class="page-header align-items-start min-vh-100"
-        th:style="|background-image: url('@{/assets/image/ian-valerio-road-header-unsplash.jpg}')|">
+    <div id="main-page" class="page-header align-items-start min-vh-100">
         <div class="container my-auto">
             <div class="row justify-content-center">
                 <div class="col-lg-8 col-md-10 col-sm-8 mb-2">
                     <div class="alert alert-success" role="alert" th:if="${successMessage}"
-                        th:utext="'<strong>Great! </strong>' + ${successMessage}">
+                        th:utext=" '<strong> Great! </strong>' + ${successMessage}">
                     </div>
                 </div>
             </div>
@@ -42,7 +41,7 @@
                             </div>
                         </div>
                         <div class="card-body">
-                            <form role="form" class="text-start" method="post" th:action="@{/login}">
+                            <form class="text-start" method="post" th:action="@{/login}">
                                 <input type="hidden" sec:csrf="true" />
                                 <div class="input-group input-group-outline my-3">
                                     <label class="form-label" for="username">User Name</label>
@@ -82,8 +81,9 @@
                     </div>
                 </div>
             </div>
-        </div><!--footer-->
+        </div>
     </div>
+    <!--footer-->
     <footer th:replace="~{auth/fragment/footer :: footer}"></footer>
     <!--   Core JS Files   -->
     <th:block th:insert="~{fragments/core :: btScriptInclude}"></th:block>

--- a/src/main/resources/templates/fragments/menuContent.html
+++ b/src/main/resources/templates/fragments/menuContent.html
@@ -12,7 +12,7 @@
         <h6 class="dropdown-header text-dark font-weight-bolder d-flex align-items-center px-1">
             Dashboard
         </h6>
-        <a th:href="@{/setting}" class="dropdown-item border-radius-md">
+        <a th:href="@{/settings}" class="dropdown-item border-radius-md">
             <span>Settings</span>
         </a>
         <a th:href="@{/watchlist}" class="dropdown-item border-radius-md">

--- a/src/main/resources/templates/fragments/menuContent.html
+++ b/src/main/resources/templates/fragments/menuContent.html
@@ -12,7 +12,7 @@
         <h6 class="dropdown-header text-dark font-weight-bolder d-flex align-items-center px-1">
             Dashboard
         </h6>
-        <a href="#" class="dropdown-item border-radius-md">
+        <a th:href="@{/setting}" class="dropdown-item border-radius-md">
             <span>Settings</span>
         </a>
         <a th:href="@{/watchlist}" class="dropdown-item border-radius-md">

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -41,9 +41,9 @@
                                 </button>
                             </div>
                             <!-- Back Link -->
-                            <div class="text-center mt-3">
-                                <a href="/main" class="text-primary">Back to Dashboard</a>
-                            </div>
+<div class="text-center mt-3">
+    <a th:href="@{/main}" class="text-primary">Back to Dashboard</a>
+</div>
                         </div>
                     </div>
                 </div>

--- a/src/main/resources/templates/settings.html
+++ b/src/main/resources/templates/settings.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head th:replace="~{fragments/core :: head(~{::title},_)}">
+    <title>Account Settings</title>
+</head>
+
+<body>
+    <div id="main-page" class="page-header align-items-start min-vh-100">
+        <div class="container mt-5">
+            <div class="row justify-content-center">
+                <div class="col-md-6">
+                    <div class="card shadow-sm">
+                        <div class="card-body p-4">
+                            <h2 class="text-center mb-4">Account Settings</h2>
+                            <!-- Change Password Form -->
+                            <form class="text-start" th:action="@{/changePassword}" method="post"
+                                th:object="${passwordForm}">
+                                <input type="hidden" sec:csrf="true" />
+                                <div class=" input-group input-group-outline mb-3">
+                                    <label for="oldPass" class="form-label">Current Password</label>
+                                    <input type="password" class="form-control" id="oldPass" th:field="*{oldPass}">
+                                </div>
+                                <div class=" input-group input-group-outline mb-3">
+                                    <label for="newPass" class="form-label">New Password</label>
+                                    <input type="password" class="form-control" id="newPass" th:field="*{newPass}">
+                                </div>
+                                <div th:if="${#fields.hasErrors('*')}" class="alert alert-danger text-center">
+                                    <span th:errors="*">Password change failed. Please check your inputs.</span>
+                                </div>
+                                <div class="text-center">
+                                    <button type="submit" class="btn btn-primary w-100">Change Password</button>
+                                </div>
+                            </form>
+                            <!-- Delete Account Button and Modal -->
+                            <hr class="my-4">
+                            <div class="text-center">
+                                <button type="button" class="btn btn-danger w-100" data-bs-toggle="modal"
+                                    data-bs-target="#deleteAccountModal">
+                                    Delete Account
+                                </button>
+                            </div>
+                            <!-- Back Link -->
+                            <div class="text-center mt-3">
+                                <a href="/main" class="text-primary">Back to Dashboard</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Delete Account Confirmation Modal -->
+    <div class="modal fade" id="deleteAccountModal" tabindex="-1" aria-labelledby="deleteAccountModalLabel"
+        aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="deleteAccountModalLabel">Confirm Account Deletion</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    Are you sure you want to delete your account? This action cannot be undone.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <form th:action="@{/account/delete}" method="post">
+                        <button type="submit" class="btn btn-danger">Delete Account</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <footer th:replace="~{auth/fragment/footer :: footer}"></footer>
+    <!--   Core JS Files   -->
+    <th:block th:insert="~{fragments/core :: btScriptInclude}"></th:block>
+</body>
+
+</html>


### PR DESCRIPTION
Implement password change feature, enhance repository support for password hashing, and refactor related components for improved maintainability and consistency. Minor UI improvements included.

## Summary by Sourcery

Add password change functionality by introducing a settings page and related endpoints, implement PasswordService for validating and updating hashed passwords, extend repository support, refactor security configuration, and apply minor UI and template enhancements

New Features:
- Add account settings page accessible at /settings with change password form and delete account modal
- Implement /changePassword endpoint to verify current password and update to a new hashed password via PasswordService

Enhancements:
- Extend AppAccRepository with methods to retrieve and update password hash
- Introduce SettingDTO record with custom password validation
- Move PasswordEncoder bean into a dedicated SecurityConfig
- Update CSS and Thymeleaf templates for consistent background styling and add menu link to settings