### PR TITLE
Enhance development and production YAML configurations for secrets and MariaDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG BUILD_PROFILE=local
 RUN mvn clean package -DskipTests -P${BUILD_PROFILE},container-build-base
 
 # Stage 2: Runtime
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine AS runtime
 WORKDIR /opt/app
 
 # Copy the built jar from builder stage

--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -13,19 +13,20 @@ RUN mvn dependency:go-offline -B
 # Copy source code
 COPY src/ ./src/
 
+
 # Build the application (FORCE the 'prod' profile for Cloud Run)
-RUN mvn clean package -DskipTests -Pprod,container-build-base  # <-- HARDCODED 'prod' profile
+ARG BUILD_PROFILE=prod 
+RUN mvn clean package -DskipTests -P${BUILD_PROFILE},container-build-base  
 
 # Stage 2: Runtime
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine AS runtime
 WORKDIR /opt/app
 
-# Copy the built jar from builder stage
-COPY --from=builder /build/target/AnimeRecommendationApp.jar app.jar
-
 # Create non-root user for security
-RUN addgroup -S spring && adduser -S spring -G spring && \
-  chown -R spring:spring /opt/app
+RUN addgroup -S spring && adduser -S spring -G spring
+
+# Copy the built jar from builder stage
+COPY --from=builder --chown=spring:spring /build/target/AnimeRecommendationApp.jar app.jar
 
 # Expose application port
 EXPOSE 8080
@@ -35,11 +36,8 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:8080/actuator/health || exit 1
 
 # Copy entrypoint script
-# 1. Copy the file without changing permissions
-COPY docker-entrypoint.sh /opt/app/
-
-# 2. Change the permissions using a separate RUN command
-RUN chmod a+x /opt/app/docker-entrypoint.sh
+# 3. Copy script and set permissions in ONE step
+COPY --chown=spring:spring --chmod=755 docker-entrypoint.sh /opt/app/
 # Switch to non-root user
 USER spring:spring
 

--- a/compose-cloud.yaml
+++ b/compose-cloud.yaml
@@ -1,0 +1,44 @@
+services:
+  anime-recommend-app:
+    image: anime-recommend-app:latest
+    container_name: anime_Recommendation_App
+    environment:
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-prod}
+      - DB_URL=${DB_URL}
+      - DB_NAME=${DB_NAME}
+      - DB_USERNAME=${DB_USERNAME}
+      - "JAVA_OPTS=-Xms512m -Xmx1024m"
+    secrets:
+      - db_password
+
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8080/actuator/health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - anime-network
+    restart: unless-stopped
+
+volumes:
+  database:
+    driver: local
+
+networks:
+  anime-network:
+    driver: bridge
+
+secrets:
+  db_password:
+    file: ./secrets/db_pass.txt

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,6 @@ services:
     image: "mysql:lts"
     container_name: anime_db
     environment:
-      - MYSQL_DATABASE:{DB_NAME}
       - MYSQL_USER:${DB_USERNAME}
       - MYSQL_PASSWORD_FILE:/run/secrets/db_password
     secrets:

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<google-cloud-sql.version>1.26.1</google-cloud-sql.version>
 	</properties>
 
 	<dependencies>
@@ -90,6 +89,7 @@
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- Development Tools -->
@@ -286,6 +286,7 @@
 					<groupId>org.mariadb.jdbc</groupId>
 					<artifactId>mariadb-java-client</artifactId>
 					<scope>runtime</scope>
+					<optional>true</optional>
 				</dependency>
 			</dependencies>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -92,13 +92,12 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!-- Google Cloud SQL (Production only) -->
 		<dependency>
-			<groupId>com.google.cloud.sql</groupId>
-			<artifactId>mysql-socket-factory-connector-j-8</artifactId>
-			<version>${google-cloud-sql.version}</version>
-			<optional>true</optional>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<scope>runtime</scope>
 		</dependency>
+
 
 		<!-- Development Tools -->
 		<dependency>
@@ -147,6 +146,8 @@
 			<artifactId>spring-restdocs-mockmvc</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+
 	</dependencies>
 
 	<build>
@@ -280,24 +281,33 @@
 			<!-- The final JAR cleanup is provided by 'container-build-base' -->
 		</profile>
 
-		<!-- 3. Production Profile (Google Cloud) - Now contains only unique dependencies -->
-
+		<!-- 3. Production Profile  - Now contains only unique dependencies mariaDB -->
+		
 		<profile>
 			<id>prod</id>
 			<properties>
 				<spring.profiles.active>prod</spring.profiles.active>
 			</properties>
 			<dependencies>
-				<!-- Google Cloud SQL required for production -->
 				<dependency>
-					<groupId>com.google.cloud.sql</groupId>
-					<artifactId>mysql-socket-factory-connector-j-8</artifactId>
-					<version>${google-cloud-sql.version}</version>
+					<groupId>org.mariadb.jdbc</groupId>
+					<artifactId>mariadb-java-client</artifactId>
 				</dependency>
 			</dependencies>
 			<build>
 				<plugins>
-					<!-- No unique plugins are needed here. -->
+					<plugin>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<excludes combine.children="append">
+								<exclude>
+									<groupId>com.mysql</groupId>
+									<artifactId>mysql-connector-j</artifactId>
+								</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -92,13 +92,6 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.mariadb.jdbc</groupId>
-			<artifactId>mariadb-java-client</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-
-
 		<!-- Development Tools -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -282,7 +275,7 @@
 		</profile>
 
 		<!-- 3. Production Profile  - Now contains only unique dependencies mariaDB -->
-		
+
 		<profile>
 			<id>prod</id>
 			<properties>
@@ -292,6 +285,7 @@
 				<dependency>
 					<groupId>org.mariadb.jdbc</groupId>
 					<artifactId>mariadb-java-client</artifactId>
+					<scope>runtime</scope>
 				</dependency>
 			</dependencies>
 			<build>

--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ The application uses a containerized MySQL database with anime data from Kaggle 
 
 ### Configuration
 Key configuration options in `application.properties`:
+
 - Database connection: `spring.datasource.url=jdbc:mysql://localhost:3306/mydatabase`
 - Security settings: Password encoding, session management
 - JPA settings: SQL logging, hibernate configuration

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,11 @@
 spring:
+  docker:
+    compose:
+      enabled: false
   config:
     activate:
       on-profile: dev
+    import: "optional:file:./secrets/secrets.properties"
   application:
     name: animeRecommendationSystem
   datasource:
@@ -11,9 +15,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-
       ddl-auto: validate
-
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,10 +2,12 @@ spring:
   config:
     activate:
       on-profile: prod
+    import:
+      - optional:configtree:/run/secrets/
   application:
     name: animeRecommendationSystem
   datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.mariadb.jdbc.Driver
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
@@ -13,8 +15,9 @@ spring:
       maximum-pool-size: 5
       minimum-idle: 1
       connection-timeout: 30000
-      idle-timeout: 600000
-      max-lifetime: 1800000
+      idle-timeout: 540000      # 9 minut
+      max-lifetime: 600000     #  limit is 30min 
+      keepalive-time: 30000               
   jpa:
     hibernate:
       ddl-auto: none
@@ -41,6 +44,9 @@ logging:
         web: WARN
         security: WARN
       hibernate: WARN
+    com:
+      zaxxer:
+        hikari: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg%n"
     file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,9 +15,9 @@ spring:
       maximum-pool-size: 5
       minimum-idle: 1
       connection-timeout: 30000
-      idle-timeout: 540000      # 9 minut
-      max-lifetime: 600000     #  limit is 30min 
-      keepalive-time: 30000               
+      idle-timeout: 540000
+      max-lifetime: 600000
+      keepalive-time: 30000
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
separeting secrets from enviroments variable moving production to mariaDB instead of google cloud

## Summary by Sourcery

Switch production database configuration from Google Cloud MySQL to MariaDB and adjust environment-specific secret handling.

New Features:
- Introduce Docker Compose configuration for running the application in a production-like environment with secrets-based DB credentials.

Enhancements:
- Replace Google Cloud SQL connector dependencies with MariaDB JDBC driver in main and production Maven profiles.
- Update production and development Spring profiles to import secrets from Docker secrets/config files and tune HikariCP connection pool settings.
- Adjust Dockerfile base image stage naming and clean up Compose database service environment configuration.
- Document database connection configuration details in the README.